### PR TITLE
fixes for puppet 4 compatibility and added epel repo

### DIFF
--- a/manifests/open.pp
+++ b/manifests/open.pp
@@ -2,7 +2,7 @@ class d3r::open
 {
   #epel repo
   exec { 'install_epel':
-    command => '/bin/yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm',
+    command => '/bin/yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',
     creates => '/etc/yum/yum.repos.d/epel.repo'
   }
 

--- a/manifests/open.pp
+++ b/manifests/open.pp
@@ -1,5 +1,11 @@
 class d3r::open
 {
+  #epel repo
+  exec { 'install_epel':
+    command => '/bin/yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm',
+    creates => '/etc/yum/yum.repos.d/epel.repo'
+  }
+
   Package { ensure => 'installed' }
   $python_deps    = [ 'python-pip', 'python-psutil', 'python-virtualenv', 'python-tox', 'pylint', 'python-coverage' ]
   $perl_deps      = [ 'perl-Archive-Tar', 'perl-List-MoreUtils' ]

--- a/manifests/open.pp
+++ b/manifests/open.pp
@@ -29,7 +29,7 @@ class d3r::open
     gpgcheck            => 1,
     gpgkey              => 'https://copr-be.cloud.fedoraproject.org/results/giallu/rdkit/pubkey.gpg',
     repo_gpgcheck       => 0,
-    skip_if_unavailable => True,
+    skip_if_unavailable => 'True'
   }
 
   exec { 'install_conda':
@@ -49,7 +49,7 @@ class d3r::open
   package { $pip_packages:
     ensure   => 'installed',
     provider => 'pip',
-    require  => Package ['python-pip'],
+    require  => Package['python-pip'],
   }
 
   #blast


### PR DESCRIPTION
To get this config to work I had to make a couple fixes to get puppet4 to stop complaining. I also had to add the epel yum repo since it is not installed. I probably am doing the inclusion of epel yum repo incorrectly. 