### PR TITLE
Chrisdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contains puppet configuration to provision a machine that can run D3R software.
 * [Pymol][pymol] 1.8.4
 * [Rdkit][rdkit] 2016.03.3
 * [NCBI Blast][blast] 2.3.0
-* [Openeye][openeye] (latest)
+* [Openeye][openeye] (2017.6.1)
 
 ### Applying this configuration manually
 

--- a/manifests/open.pp
+++ b/manifests/open.pp
@@ -60,7 +60,7 @@ class d3r::open
 
   # Openeye install that will work in puppet in versions older then 4.1
   exec { 'install_openeye':
-    command => '/usr/bin/pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits',
+    command => '/usr/bin/pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits==2017.6.1',
     creates => '/usr/bin/openeye_tests.py'
   }
 

--- a/manifests/open.pp
+++ b/manifests/open.pp
@@ -9,7 +9,7 @@ class d3r::open
   Package { ensure => 'installed' }
   $python_deps    = [ 'python2-pip', 'python-psutil', 'python-virtualenv', 'python-tox', 'pylint', 'python-coverage' ]
   $perl_deps      = [ 'perl-Archive-Tar', 'perl-List-MoreUtils' ]
-  $other_packages = [ 'libXft', 'openbabel', 'xorg-x11-xauth', 'screen', 'bzip2', 'which', 'rsync' ]
+  $other_packages = [ 'libXft', 'openbabel', 'xorg-x11-xauth', 'screen', 'bzip2', 'which', 'rsync', 'ncftp' ]
   $pymol_deps     = [ 'subversion', 'gcc', 'gcc-c++', 'kernel-devel', 'python-devel', 'tkinter', 'python-pmw', 'glew-devel', 'freeglut-devel', 'libpng-devel', 'freetype-devel', 'libxml2-devel']
   $mesa_packages  = [ 'mesa-libGL-devel','mesa-libEGL-devel','mesa-libGLES-devel' ]
   $pip_packages   = [ 'argparse','psutil','biopython','xlsxwriter','ftpretty','wheel','flake8','lockfile','easywebdav','d3r' ]


### PR DESCRIPTION
Added ncftp package to yum install list and set specific version of openeye to install 2017.6.1 cause the latest versions require python 3+ and enabling that requires a rework of this entire install.